### PR TITLE
Fix issue with lazy loading of the `g:import_sort_settings` setting when setting it via a local .vimrc

### DIFF
--- a/plugin/vimport-sort.vim
+++ b/plugin/vimport-sort.vim
@@ -12,39 +12,47 @@ let g:loaded_vimport_sort = 1
 
 " Sort imports
 function! SortImports()
-  let save_cursor = getpos(".")
-  let curFiletype = &filetype
+  if (exists('g:import_sort_settings'))
+    let save_cursor = getpos(".")
+    let curFiletype = &filetype
 
-  let errs = []
+    let errs = []
 
-  if has_key(g:import_sort_settings, curFiletype)
-    let obj = g:import_sort_settings[curFiletype]
+    if has_key(g:import_sort_settings, curFiletype)
+      let obj = g:import_sort_settings[curFiletype]
 
-    if has_key(obj, "import_prefix")
-      let import_prefix = copy(obj["import_prefix"])
+      if has_key(obj, "import_prefix")
+        let import_prefix = copy(obj["import_prefix"])
+      else
+        call add(errs, "g:import_sort_groups['".curFiletype."']['import_prefix'] not set!")
+      endif
+
+      if has_key(obj, "import_groups")
+        let import_groups = copy(obj["import_groups"])
+      else
+        call add(errs, "g:import_sort_groups['".curFiletype."']['import_groups'] not set!")
+      endif
     else
-      call add(errs, "g:import_sort_groups['".curFiletype."']['import_prefix'] not set!")
+      call add(errs, "g:import_sort_groups['".curFiletype."'] not set!")
     endif
 
-    if has_key(obj, "import_groups")
-      let import_groups = copy(obj["import_groups"])
+    if len(errs) == 0
+      call s:groupImportSort(import_prefix, import_groups)
     else
-      call add(errs, "g:import_sort_groups['".curFiletype."']['import_groups'] not set!")
+      for err in errs
+        echo s:errorMsg(err)
+      endfor
+      echo s:errorMsg("Run ':h :SortImports' for set up information.")
     endif
-  else
-    call add(errs, "g:import_sort_groups['".curFiletype."'] not set!")
-  endif
 
-  if len(errs) == 0
-    call s:groupImportSort(import_prefix, import_groups)
+    call setpos('.', save_cursor)
   else
-    for err in errs
-      echo "vimport-sort| ".err
-    endfor
-    echo "vimport-sort| Run ':h :SortImports' for set up information."
+    echo s:errorMsg("g:import_sort_settings is not set. See `:h :SortImports` for set up information")
   endif
+endfunction
 
-  call setpos('.', save_cursor)
+function! s:errorMsg(err)
+  return "vimport-sort| " . a:err
 endfunction
 
 function! s:groupImportSort(prefixIn, patternsIn)

--- a/plugin/vimport-sort.vim
+++ b/plugin/vimport-sort.vim
@@ -10,8 +10,6 @@ if exists('g:loaded_vimport_sort') || &cp
 endif
 let g:loaded_vimport_sort = 1
 
-let g:import_sort_settings = {}
-
 " Sort imports
 function! SortImports()
   let save_cursor = getpos(".")


### PR DESCRIPTION
This was causing issues when setting a variable in a local `.vimrc`.

I believe what is happening is that the local .vimrc runs first but then this file (in plugin) loads and resets the setting to `{}`. By removing the initialization we keep the one passed in the local vimrc. 

I noticed this by look at Derek's code (his code doesn't have that bind at the beginning). 
https://github.com/derekwyatt/vim-scala/blob/a6a350f7c632d0e640b57f9dcc7e123409a7bcd7/plugin/scala.vim#L59

I tested this and it works now. 